### PR TITLE
修正しました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,16 +11,15 @@
       "dependencies": {
         "cli-color": "^2.0.3",
         "cli-spinner": "^0.2.10",
-        "node-emoji": "^2.1.0",
         "yesno": "^0.4.0"
       },
       "devDependencies": {
         "@types/cli-color": "^2.0.2",
         "@types/cli-spinner": "^0.2.1",
         "@types/node": "^20.4.5",
-        "@types/node-emoji": "^2.1.0",
         "cross-env": "^7.0.3",
         "esbuild": "^0.18.14",
+        "node-emoji": "^2.1.0",
         "npm-run-all": "^4.1.5",
         "pkg": "^5.8.1",
         "rimraf": "^5.0.1",
@@ -636,6 +635,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
       "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -663,16 +663,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
       "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
       "dev": true
-    },
-    "node_modules/@types/node-emoji": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node-emoji/-/node-emoji-2.1.0.tgz",
-      "integrity": "sha512-LBGWP2LL5A+PpcvzrgXCFcHt9N1l5bqQn05ZUQFFM625k/tmc2w9ghT4kUwQN6gIPlX6qnDOfekmJmV9BywV9g==",
-      "deprecated": "This is a stub types definition. node-emoji provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "node-emoji": "*"
-      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -903,6 +893,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -1181,7 +1172,8 @@
     "node_modules/emojilib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "dev": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2437,6 +2429,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.0.tgz",
       "integrity": "sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==",
+      "dev": true,
       "dependencies": {
         "@sindresorhus/is": "^3.1.2",
         "char-regex": "^1.0.2",
@@ -3170,6 +3163,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
       "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "dev": true,
       "dependencies": {
         "unicode-emoji-modifier-base": "^1.0.0"
       },
@@ -3586,6 +3580,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "@types/cli-color": "^2.0.2",
     "@types/cli-spinner": "^0.2.1",
     "@types/node": "^20.4.5",
-    "@types/node-emoji": "^2.1.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.18.14",
+    "node-emoji": "^2.1.0",
     "npm-run-all": "^4.1.5",
     "pkg": "^5.8.1",
     "rimraf": "^5.0.1",
@@ -26,7 +26,6 @@
   "dependencies": {
     "cli-color": "^2.0.3",
     "cli-spinner": "^0.2.10",
-    "node-emoji": "^2.1.0",
     "yesno": "^0.4.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ class Main{
     private fileList: string[] = [];
     private unProcessed: string[] = [];
     private processed: string[] = [];
-    private latestPrefix: number  = 0;
+    private latestPrefix: number = 0;
     private spinner = new Spinner(clc.cyan("Watching for file changes..."));    // ファイル変更監視中のスピナー
 
 
@@ -76,18 +76,18 @@ class Main{
 
     // メインのループ
     loop(){
-        let newPrefix;
+        let newPrefix: number;
 
         this.analyzeFiles();                        // ファイル一覧を分析する
         newPrefix = this.latestPrefix + 1;          // 最新の通し番号を1つ増やす
-        if (this.unProcessed.length == 0){          // 未処理のファイルが存在しなかったらこのループは終了
+        if (this.unProcessed.length === 0){          // 未処理のファイルが存在しなかったらこのループは終了
             return;
         }
                                                     // 未処理のファイルが1つでもあったらここから
         this.spinner.stop();                        // スピナーを停止
         console.log();                              // 空行
         for (const oldName of this.unProcessed){    // 未処理のファイルを1つずつ処理
-            const newName = ("000" + newPrefix).slice(-3) + "_" +oldName;
+            const newName = ("000" + newPrefix.toString()).slice(-3) + "_" + oldName;
             
             fs.renameSync(path.resolve(this.workDir, oldName), path.resolve(this.workDir, newName));
             console.log(`${oldName}\t>>\t${clc.greenBright(newName)}`);
@@ -112,7 +112,7 @@ class Main{
                 return 0;
         });
         // 添え字がついてないやつのリスト
-        this.unProcessed = this.fileList.filter((value)=>{
+        this.unProcessed = this.fileList.filter(value=>{
             return !this.regEx.test(value);
         });
         // 添え字がついてるやつのリスト
@@ -120,14 +120,14 @@ class Main{
             return this.regEx.test(value);
         }).sort();
         // 一番新しい添え字
-        this.latestPrefix = (this.processed.length != 0) ? (parseInt(this.processed[this.processed.length - 1].slice(0, 3))) : -1;
+        this.latestPrefix = this.processed.length !== 0 ? parseInt(this.processed[this.processed.length - 1].slice(0, 3)) : -1;
     }
 
     // ファイルのリストを取得するやつ（フォルダには反応しないやつ）
     getFileList(filePath: string): string[]{
         // 対象がファイルでかつ実行可能ファイルでない場合
         return fs.readdirSync(filePath, {withFileTypes: true}).filter(dirent =>{
-            return dirent.isFile() && dirent.name != this.execName;
+            return dirent.isFile() && dirent.name !== this.execName;
         }).map(dirent => {
             return dirent.name;
         })


### PR DESCRIPTION
コード読んでたら自分でも直せそうだな、と思ったところがあるので手を加えてみました。

変更点は以下の通りです。
- 連番を生成するところで暗黙の型変換が起こってたので、つじつま合わせ
- DefinitelyTyped にある node-emoji の型定義ファイルが [deprecated](https://www.npmjs.com/package/@types/node-emoji) になっていたので、すでに公式から出ているものに修正

バイナリ作るところまでは確認できていませんが、一応WSL上での動作は確認できた（下参照）ので確認お願いしたいです。  
（にもかかわらずブランチ切らずに作業しちゃってごめんなさい）

```bash
$ touch test/{1..100}.txt
$ ls test
1.txt    12.txt  16.txt  2.txt   23.txt  27.txt  30.txt  34.txt  38.txt  41.txt  45.txt  49.txt  52.txt  56.txt  6.txt   63.txt  67.txt  70.txt  74.txt  78.txt  81.txt  85.txt  89.txt  92.txt  96.txt
10.txt   13.txt  17.txt  20.txt  24.txt  28.txt  31.txt  35.txt  39.txt  42.txt  46.txt  5.txt   53.txt  57.txt  60.txt  64.txt  68.txt  71.txt  75.txt  79.txt  82.txt  86.txt  9.txt   93.txt  97.txt
100.txt  14.txt  18.txt  21.txt  25.txt  29.txt  32.txt  36.txt  4.txt   43.txt  47.txt  50.txt  54.txt  58.txt  61.txt  65.txt  69.txt  72.txt  76.txt  8.txt   83.txt  87.txt  90.txt  94.txt  98.txt
11.txt   15.txt  19.txt  22.txt  26.txt  3.txt   33.txt  37.txt  40.txt  44.txt  48.txt  51.txt  55.txt  59.txt  62.txt  66.txt  7.txt   73.txt  77.txt  80.txt  84.txt  88.txt  91.txt  95.txt  99.txt

$ npm test
 Prefixer - Auto Prefix Adder for files v0.2.0
        Made with ♥︎ by Bistalink. MIT License.

Working Directory:       /home/iigau/Prefixer/test
Executable name:         node

Target Expression:       /^[0-9]{3}_/

----------
Press Ctrl + C or close console window to quit
----------

Before begin, Is the detected working directory correct?
If not, your files can accidentaly get renamed. (yes / no) yes

⢄ Watching for file changes...
1.txt   >>      000_1.txt
10.txt  >>      001_10.txt
100.txt >>      002_100.txt
11.txt  >>      003_11.txt
12.txt  >>      004_12.txt
...
```


よろしくお願いします！